### PR TITLE
Ubuntu 18.04 does not come preinstalled with these 2 packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ mainline is written using Vala and GTK3. Source code and binaries are available 
 		sudo apt install mainline
 
 ### Build
-		sudo apt install libgee-0.8-dev libjson-glib-dev libvte-2.91-dev valac
+		sudo apt install libgee-0.8-dev libjson-glib-dev libvte-2.91-dev valac aptitude aria2
 		git clone https://github.com/aljex/mainline.git
 		cd mainline
 		make


### PR DESCRIPTION
The current instruction will result in an error that says you have to install the following 2 packages.