### PR TITLE
Add button to hide older than 5.0 kernels

### DIFF
--- a/src/Common/LinuxKernel.vala
+++ b/src/Common/LinuxKernel.vala
@@ -46,6 +46,7 @@ public class LinuxKernel : GLib.Object, Gee.Comparable<LinuxKernel> {
 	public static string CURRENT_USER_HOME;
 	
 	public static bool hide_older;
+	public static bool hide_older5; //Add bool for hide older then 5.0 kernels
 	public static bool hide_unstable;
 		
 	public static LinuxKernel kernel_active;
@@ -245,6 +246,7 @@ public class LinuxKernel : GLib.Object, Gee.Comparable<LinuxKernel> {
 	private static void query_thread() {
 
 		log_debug("query: hide_older: %s".printf(hide_older.to_string()));
+		log_debug("query: hide_older5kernels: %s".printf(hide_older5.to_string()));
 		log_debug("query: hide_unstable: %s".printf(hide_unstable.to_string()));
 
 		//DownloadManager.reset_counter();
@@ -270,11 +272,15 @@ public class LinuxKernel : GLib.Object, Gee.Comparable<LinuxKernel> {
 		// TODO: Implement locking for multiple download threads
 
 		var kern_4 = new LinuxKernel.from_version("4.0");
+		var kern_5 = new LinuxKernel.from_version("5.0");
 		
 		status_line = "";
 		progress_total = 0;
 		progress_count = 0;
 		foreach(var kern in kernel_list){
+			if (hide_older5 && (kern.compare_to(kern_5) < 0)){
+				continue;
+			}
 			if (hide_older && (kern.compare_to(kern_4) < 0)){
 				continue;
 			}
@@ -305,6 +311,11 @@ public class LinuxKernel : GLib.Object, Gee.Comparable<LinuxKernel> {
 
 			if (!kern.is_valid){
 				//log_debug("invalid: %s".printf(kern.version_main));
+				continue;
+			}
+
+			if (hide_older5 && (kern.compare_to(kern_5) < 0)){
+				log_debug("older than 5.0: %s".printf(kern.version_main));
 				continue;
 			}
 
@@ -1153,11 +1164,15 @@ public class LinuxKernel : GLib.Object, Gee.Comparable<LinuxKernel> {
 		log_draw_line();
 
 		var kern_4 = new LinuxKernel.from_version("4.0");
+		var kern_5 = new LinuxKernel.from_version("5.0");
 		foreach(var kern in kernel_list){
 			if (!kern.is_valid){
 				continue;
 			}
 			if (hide_unstable && kern.is_unstable){
+				continue;
+			}
+			if (hide_older5 && (kern.compare_to(kern_5) < 0)){
 				continue;
 			}
 			if (hide_older && (kern.compare_to(kern_4) < 0)){

--- a/src/Common/Main.vala
+++ b/src/Common/Main.vala
@@ -142,6 +142,7 @@ public class Main : GLib.Object{
 		config.set_string_member("notify_dialog", notify_dialog.to_string());
 		config.set_string_member("hide_unstable", LinuxKernel.hide_unstable.to_string());
 		config.set_string_member("hide_older", LinuxKernel.hide_older.to_string());
+		config.set_string_member("hide_older5", LinuxKernel.hide_older5.to_string());
 		config.set_string_member("notify_interval_unit", notify_interval_unit.to_string());
 		config.set_string_member("notify_interval_value", notify_interval_value.to_string());
         config.set_string_member("connection_timeout_seconds", connection_timeout_seconds.to_string());
@@ -181,6 +182,7 @@ public class Main : GLib.Object{
 			// initialize static
 			LinuxKernel.hide_unstable = true;
 			LinuxKernel.hide_older = true;
+			LinuxKernel.hide_older5 = true;
 			return;
 		}
 
@@ -206,6 +208,7 @@ public class Main : GLib.Object{
 
 		LinuxKernel.hide_unstable = json_get_bool(config, "hide_unstable", true);
 		LinuxKernel.hide_older = json_get_bool(config, "hide_older", true);
+		LinuxKernel.hide_older5 = json_get_bool(config, "hide_older5", true);
 
 		log_debug("Load config file: %s".printf(APP_CONFIG_FILE));
 	}

--- a/src/Gtk/MainWindow.vala
+++ b/src/Gtk/MainWindow.vala
@@ -274,6 +274,7 @@ public class MainWindow : Gtk.Window{
 		}
 
 		var kern_4 = new LinuxKernel.from_version("4.0");
+		var kern_5 = new LinuxKernel.from_version("5.0");
 
 		TreeIter iter;
 		bool odd_row = false;
@@ -284,9 +285,13 @@ public class MainWindow : Gtk.Window{
 			if (LinuxKernel.hide_unstable && kern.is_unstable){
 				continue;
 			}
+			if (LinuxKernel.hide_older5 && (kern.compare_to(kern_5) < 0)){
+				continue;
+			}
 			if (LinuxKernel.hide_older && (kern.compare_to(kern_4) < 0)){
 				continue;
 			}
+
 
 			odd_row = !odd_row;
 

--- a/src/Gtk/SettingsDialog.vala
+++ b/src/Gtk/SettingsDialog.vala
@@ -41,6 +41,7 @@ public class SettingsDialog : Gtk.Dialog {
 	private Gtk.CheckButton chk_notify_dialog;
 	private Gtk.CheckButton chk_hide_unstable;
 	private Gtk.CheckButton chk_hide_older;
+	private Gtk.CheckButton chk_hide_older5;
 		
 	public SettingsDialog.with_parent(Window parent) {
 		set_transient_for(parent);
@@ -174,6 +175,17 @@ public class SettingsDialog : Gtk.Dialog {
 		
 		chk.toggled.connect(()=>{
 			LinuxKernel.hide_unstable = chk_hide_unstable.active;
+		});
+
+		// chk_hide_older5
+		chk = new CheckButton.with_label(_("Hide kernels older than 5.0"));
+		chk.active = LinuxKernel.hide_older5;
+		chk.margin_start = 6;
+		vbox_main.add(chk);
+		chk_hide_older5 = chk;
+		
+		chk.toggled.connect(()=>{
+			LinuxKernel.hide_older5 = chk_hide_older5.active;
 		});
 
 		// chk_hide_older


### PR DESCRIPTION
I am no vala or GTK programmer, so here may be dirty dragons and is not perfect like it isn't hiding or graying out the "Hide kernels older then 4.0" button if the "Hide kernels older then 5.0" button is pressed. But it works.

If you have any feedback, no matter if you want to merge it or not, feel free.