### PR TITLE
skip in check for new kernel if the kernel in question is already insstalled

### DIFF
--- a/src/Common/LinuxKernel.vala
+++ b/src/Common/LinuxKernel.vala
@@ -654,6 +654,15 @@ public class LinuxKernel : GLib.Object, Gee.Comparable<LinuxKernel> {
 			if (kern.is_installed){
 				continue;
 			}
+			
+			//check if the kernel is already installed in apt and skip if
+			string std_out;
+			exec_sync("apt list --installed 2>/dev/null | grep linux-image-unsigned | cut -d / -f 1 | cut -d'-' -f 4-6", out std_out, null);
+			string version_temp = kern.version_main;
+			if (version_temp.contains(std_out))
+			{
+				continue;
+			}
 
 			//log_msg("check: %s".printf(kern.version_main));
 


### PR DESCRIPTION
Hello

Please don't take the code in this PR too serious, I am no vala programmer and just hacked something together I don't even know if it works.
The issue I have is that after updating the kernel, the check for newer kernels is still running, continuously informing me to update the kernel, just because I haven't yet rebooted.

Take this more as a bug report because I do not believe this code is usable.