### PR TITLE
added ci for automatic package build

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -17,6 +17,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: install dependencies
-      run: sudo apt install debhelper valac libgtk-3-dev libgee-0.8-dev libjson-glib-dev libvte-2.91-dev lsb-release dh-make devscripts build-essential
+      run: sudo apt-get update && sudo apt-get install debhelper valac libgtk-3-dev libgee-0.8-dev libjson-glib-dev libvte-2.91-dev lsb-release dh-make devscripts build-essential
     - name: automatic debuild
       run: debuild -uc -us

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,0 +1,19 @@
+name: C/C++ CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: sudo apt install debhelper valac libgtk-3-dev libgee-0.8-dev libjson-glib-dev libvte-2.91-dev lsb-release
+    - name: automatic debuild
+      run: debuild

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -14,6 +14,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: install dependencies
-      run: sudo apt install debhelper valac libgtk-3-dev libgee-0.8-dev libjson-glib-dev libvte-2.91-dev lsb-release
+      run: sudo apt install debhelper valac libgtk-3-dev libgee-0.8-dev libjson-glib-dev libvte-2.91-dev lsb-release dh-make devscripts build-essential
     - name: automatic debuild
       run: debuild

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -8,8 +8,11 @@ on:
 
 jobs:
   build:
-
-    runs-on: [ubuntu-18.04, ubuntu-20.04]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04, ubuntu-18.04]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-18.04, ubuntu-20.04]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -16,4 +16,4 @@ jobs:
     - name: install dependencies
       run: sudo apt install debhelper valac libgtk-3-dev libgee-0.8-dev libjson-glib-dev libvte-2.91-dev lsb-release dh-make devscripts build-essential
     - name: automatic debuild
-      run: debuild
+      run: debuild -uc -us


### PR DESCRIPTION
This workflow simply builds the package for ubuntu bionic and focal on every commit to master or on pull request wanting to merge into master.
This makes testing easier since the ci builds run in a clean environment allowing reproducible results.
You can also see all warnings produced by the compiler for code that is going to be merged into master and find out if the code that is requested to merge actually compiles correctly.

I can also add some more things to the ci if you want to (like automatic upload to ppa or github release), but to allow automatic package uploading the CI needs a gpg private key to sign the package which should be added as a secret.