### PR TITLE
Add missing dependencies: `make`, `gettext`, `dpkg-dev`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,8 @@ $(dsc_file): debian/changelog $(misc_files) $(po_files)
 deb: $(deb_file)
 
 # To create the deb build env
-#sudo apt intsall pbuilder-dist
+# `pbuilder-dist` provided by `ubuntu-dev-tools`
+#sudo apt intsall ubuntu-dev-tools
 #pbuilder-dist `lsb_release -sc` create
 # To update the deb build env
 #pbuilder-dist `lsb_release -sc` update

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ sudo apt install mainline
 
 ### Build
 ```
-sudo apt install libgee-0.8-dev libjson-glib-dev libvte-2.91-dev valac aria2 lsb-release aptitude
+sudo apt install libgee-0.8-dev libjson-glib-dev libvte-2.91-dev valac aria2 lsb-release aptitude make gettext dpkg-dev
 git clone https://github.com/bkw777/mainline.git
 cd mainline
 make

--- a/README.md.src
+++ b/README.md.src
@@ -23,7 +23,7 @@ sudo apt install mainline
 
 ### Build
 ```
-sudo apt install libgee-0.8-dev libjson-glib-dev libvte-2.91-dev valac aria2 lsb-release aptitude
+sudo apt install libgee-0.8-dev libjson-glib-dev libvte-2.91-dev valac aria2 lsb-release aptitude make gettext dpkg-dev
 git clone BRANDING_GITREPO
 cd BRANDING_SHORTNAME
 make


### PR DESCRIPTION
I install Gnome desktop environment upon Ubuntu Server, some dependencies is not builtin Ubuntu Server.

make
```
$ make

Command 'make' not found
```

dpkg-dev
```
$ make

/bin/bash: dpkg-parsechangelog: command not found
```

gettext
```
$ sudo make install

/bin/bash: line 3: msgfmt: command not found
```