### PR TITLE
LinuxKernel: Don't make invalid kernels determine highest version

### DIFF
--- a/src/Common/LinuxKernel.vala
+++ b/src/Common/LinuxKernel.vala
@@ -229,6 +229,9 @@ public class LinuxKernel : GLib.Object, Gee.Comparable<LinuxKernel> {
 		highest_maj = 0;
 		foreach(var k in kernel_list){
 			//log_debug("k.version_maj = %d".printf(k.version_maj));
+			if (!k.is_valid) continue;
+			if (App.hide_unstable && k.is_unstable) continue;
+
 			if (k.version_maj > highest_maj){
 				highest_maj = k.version_maj;
 				log_debug("highest_maj = %d".printf(highest_maj));


### PR DESCRIPTION
In case there are only invalid versions for the kernel having the
highest version number, no other versions will get displayed.

In the same vein, in the case where we haven't asked to display any
unstable versions, don't make those determine the highest kernel
version.

This should fix #147.