### PR TITLE
Introduce FileDownloader and lazily download changelogs

### DIFF
--- a/src/Common/FileDownloader.vala
+++ b/src/Common/FileDownloader.vala
@@ -1,0 +1,93 @@
+using Gee;
+using TeeJee.Logging;
+
+public class FileDownloader : GLib.Object {
+    private File source;
+    private File destination;
+
+    private bool synchronously;
+    private bool started = false;
+    private bool done = false;
+
+    private Cancellable? cancellable;
+    private FileProgressCallback? progress_callback;
+
+    // Note: These delegates are only called in asynchronous mode
+    public delegate void OnFailure(Error e);
+    public OnFailure? on_failure;
+
+    public delegate void OnFinished();
+    public OnFinished? on_finished;
+
+    private FileDownloader(string uri, string destination,
+                           Cancellable? cancellable = null,
+                           owned FileProgressCallback? callback = null) throws Error {
+        var corrected_uri = uri;
+        if (uri.has_suffix("/"))
+            corrected_uri = uri.substring(0, uri.length - 1);
+
+        this.source = File.new_for_uri(corrected_uri);
+        this.destination = File.new_for_path(destination);
+
+        this.cancellable = cancellable;
+        this.progress_callback = callback;
+
+        if (cancellable != null)
+            cancellable.connect (() => done = true);
+    }
+
+    private FileDownloader._synchronous(string uri, string destination,
+                                        Cancellable? cancellable = null,
+                                        owned FileProgressCallback? callback = null) throws Error {
+        this(uri, destination, cancellable, callback);
+        synchronously = true;
+        start();
+    }
+
+    // Note: This static function is only an helper to avoid a `new` on the caller side
+    public static void synchronous(string uri, string destination,
+                                   Cancellable? cancellable = null,
+                                   owned FileProgressCallback? callback = null) throws Error {
+        new FileDownloader._synchronous(uri, destination, cancellable, callback);
+    }
+
+    public FileDownloader.asynchronous(string uri, string destination,
+                                       Cancellable? cancellable = null,
+                                       owned FileProgressCallback? callback = null) throws Error {
+        this(uri, destination, cancellable, callback);
+        synchronously = false;
+    }
+
+    public void start() throws Error {
+        if (started) {
+            log_error("Download already started.");
+            return;
+        }
+        started = true;
+
+        if (synchronously) {
+            source.copy(destination, FileCopyFlags.OVERWRITE, cancellable, progress_callback);
+        } else {
+            source.copy_async.begin(destination, FileCopyFlags.OVERWRITE, Priority.DEFAULT, cancellable, progress_callback,
+            (obj, res) => {
+                try {
+                    source.copy_async.end(res);
+                } catch (Error e) {
+                    if (on_failure != null)
+                        on_failure(e);
+                }
+                done = true;
+                if (on_finished != null)
+                    on_finished();
+            });
+        }
+    }
+
+    public void wait_until_finished() {
+        if (!started)
+            log_error("Waiting for a download that never started");
+
+        while (!done)
+            MainContext.@default().iteration(false);
+    }
+}

--- a/src/Common/LinuxKernel.vala
+++ b/src/Common/LinuxKernel.vala
@@ -248,7 +248,7 @@ public class LinuxKernel : GLib.Object, Gee.Comparable<LinuxKernel> {
 				if (k.version_maj < highest_maj-App.show_prev_majors) continue;
 				if (App.hide_unstable && k.is_unstable) continue;
 			}
-			if (k.is_valid && !k.cached_page_exists) progress_total += 2;
+			if (k.is_valid && !k.cached_page_exists) progress_total += 1;
 			if (notifier != null) notifier(timer, ref count);
 		}
 
@@ -276,10 +276,6 @@ public class LinuxKernel : GLib.Object, Gee.Comparable<LinuxKernel> {
 
 			// add index.html to download list
 			var item = new DownloadItem(k.cached_page_uri, file_parent(k.cached_page), file_basename(k.cached_page));
-			downloads.add(item);
-
-			// add CHANGES to download list
-			item = new DownloadItem(k.changes_file_uri, file_parent(k.changes_file), file_basename(k.changes_file));
 			downloads.add(item);
 
 			// add kernel to kernel list

--- a/src/Common/LinuxKernel.vala
+++ b/src/Common/LinuxKernel.vala
@@ -323,7 +323,7 @@ public class LinuxKernel : GLib.Object, Gee.Comparable<LinuxKernel> {
 	}
 
 	// download the main index.html listing all mainline kernels
-	private static bool download_index() throws Error {
+	private static void download_index() throws Error {
 		check_if_initialized();
 
 		dir_create(file_parent(index_page));
@@ -333,15 +333,6 @@ public class LinuxKernel : GLib.Object, Gee.Comparable<LinuxKernel> {
 		status_line = msg.strip();
 
 		FileDownloader.synchronous(URI_KERNEL_UBUNTU_MAINLINE, CACHE_DIR + "/index.html");
-
-		if (file_exists(index_page)){
-			log_msg("OK");
-			return true;
-		}
-		else{
-			log_error("ERR");
-			return false;
-		}
 	}
 
 	// read the main index.html listing all kernels

--- a/src/Common/Main.vala
+++ b/src/Common/Main.vala
@@ -66,7 +66,6 @@ public class Main : GLib.Object{
 	public string status_line = "";
 	public int64 progress_total = 0;
 	public int64 progress_count = 0;
-	public bool cancelled = false;
 
 	// state flags ----------
 	

--- a/src/Gtk/MainWindow.vala
+++ b/src/Gtk/MainWindow.vala
@@ -546,9 +546,14 @@ public class MainWindow : Gtk.Window{
 
 			return;
 		}
+		
+		var cancellable = new Cancellable();
+		cancellable.cancelled.connect (() => {
+			App.exit_app(1);
+		});
 
 		string message = _("Refreshing...");
-		var progress_window = new ProgressWindow.with_parent(this, message, true);
+		var progress_window = new ProgressWindow.with_parent(this, message, cancellable);
 		progress_window.show_all();
 
 		// TODO: Check if kernel.ubuntu.com is down
@@ -567,10 +572,6 @@ public class MainWindow : Gtk.Window{
 				return false;
 			});
 			timer_elapsed(timer, true);
-		}
-
-		if (App.cancelled){
-			App.exit_app(1);
 		}
 
 		App.status_line = LinuxKernel.status_line;

--- a/src/Gtk/MainWindow.vala
+++ b/src/Gtk/MainWindow.vala
@@ -301,7 +301,7 @@ public class MainWindow : Gtk.Window{
 			btn_install.sensitive = (selected_kernels.size == 1) && !selected_kernels[0].is_installed;
 			btn_uninstall.sensitive = selected_kernels[0].is_installed && !selected_kernels[0].is_running;
 			btn_uninstall_old.sensitive = true;
-			btn_changes.sensitive = (selected_kernels.size == 1) && file_exists(selected_kernels[0].changes_file);
+			btn_changes.sensitive = (selected_kernels.size == 1);
 		}
 	}
 
@@ -426,9 +426,21 @@ public class MainWindow : Gtk.Window{
 		btn_changes = button;
 
 		button.clicked.connect(() => {
-			if ((selected_kernels.size == 1) && file_exists(selected_kernels[0].changes_file)){
-				xdg_open(selected_kernels[0].changes_file);
+			if (selected_kernels.size != 1)
+				return;
+
+			if (! file_exists(selected_kernels[0].changes_file)) {
+				try {
+					FileDownloader.synchronous(selected_kernels[0].changes_file_uri, 
+									   		   selected_kernels[0].changes_file);
+				} catch (Error e) {
+					Gtk.MessageDialog msg = new Gtk.MessageDialog (this, Gtk.DialogFlags.MODAL, Gtk.MessageType.ERROR, Gtk.ButtonsType.OK, _("Error while downloading the changelog:\n") + e.message);
+					msg.response.connect ((response_id) => msg.destroy());
+					msg.show ();
+				}
 			}
+
+			xdg_open(selected_kernels[0].changes_file);
 		});
 
 		// settings

--- a/src/Gtk/ProgressWindow.vala
+++ b/src/Gtk/ProgressWindow.vala
@@ -47,7 +47,6 @@ public class ProgressWindow : Gtk.Window {
 
 	private string status_message;
 	private bool allow_cancel = false;
-	private bool allow_close = false;
 
 	// init
 
@@ -72,20 +71,7 @@ public class ProgressWindow : Gtk.Window {
 
 		App.cancelled = false;
 
-		this.delete_event.connect(close_window);
-
 		init_window();
-	}
-
-	private bool close_window(){
-		if (allow_close){
-			// allow window to close 
-			return false;
-		}
-		else{
-			// do not allow window to close 
-			return true;
-		}
 	}
 
 	public void init_window () {

--- a/src/Gtk/ProgressWindow.vala
+++ b/src/Gtk/ProgressWindow.vala
@@ -46,12 +46,12 @@ public class ProgressWindow : Gtk.Window {
 	private int def_height = 50;
 
 	private string status_message;
-	private bool allow_cancel = false;
+
+	private Cancellable? cancellable;
 
 	// init
 
-	public ProgressWindow.with_parent(Window parent, string message, bool allow_cancel = false) {
-
+	public ProgressWindow.with_parent(Window parent, string message, Cancellable? cancellable = null) {
 		set_transient_for(parent);
 		set_modal(true);
 		set_decorated(false);
@@ -67,9 +67,8 @@ public class ProgressWindow : Gtk.Window {
 		App.progress_total = 0;
 
 		this.status_message = message;
-		this.allow_cancel = allow_cancel;
 
-		App.cancelled = false;
+		this.cancellable = cancellable;
 
 		init_window();
 	}
@@ -130,15 +129,12 @@ public class ProgressWindow : Gtk.Window {
 		box.pack_start (button, false, false, 0);
 		btn_cancel = button;
 
-		button.clicked.connect(()=>{
-			App.cancelled = true;
+		button.clicked.connect(() => {
+			cancellable.cancel();
 			btn_cancel.sensitive = false;
 		});
 
 		show_all();
-
-		//btn_cancel.visible = allow_cancel;
-		btn_cancel.sensitive = allow_cancel;
 	}
 
 	// common


### PR DESCRIPTION
PR of the week :smile:

On `FileDownloader` (more details in the commit message):
This utility aims to be part of a replacement system for `DownloadManager`. In fact, the latter suffer from multiple flaws as its unnecessary complexity, dependence over an external tool and its design forcing the user to busy-wait.

Also, with lazy downloads of changelogs, a cold start (with an empty `.cache`) now takes 50% less times on my computer. Dropping from 36 to only 18 seconds.

As usual, it comes with it batch of code removal and overall improvements.

On a side note, have you ever considered the "rebase and merge" option instead of a classic merge? IMO, merge commits tends to really bloat the git history. 