### PR TITLE
Don't copy delegates

### DIFF
--- a/src/Common/FileDownloader.vala
+++ b/src/Common/FileDownloader.vala
@@ -30,7 +30,7 @@ public class FileDownloader : GLib.Object {
         this.destination = File.new_for_path(destination);
 
         this.cancellable = cancellable;
-        this.progress_callback = callback;
+        this.progress_callback = (owned) callback;
 
         if (cancellable != null)
             cancellable.connect (() => done = true);
@@ -39,7 +39,7 @@ public class FileDownloader : GLib.Object {
     private FileDownloader._synchronous(string uri, string destination,
                                         Cancellable? cancellable = null,
                                         owned FileProgressCallback? callback = null) throws Error {
-        this(uri, destination, cancellable, callback);
+        this(uri, destination, cancellable, (owned) callback);
         synchronously = true;
         start();
     }
@@ -48,13 +48,13 @@ public class FileDownloader : GLib.Object {
     public static void synchronous(string uri, string destination,
                                    Cancellable? cancellable = null,
                                    owned FileProgressCallback? callback = null) throws Error {
-        new FileDownloader._synchronous(uri, destination, cancellable, callback);
+        new FileDownloader._synchronous(uri, destination, cancellable, (owned) callback);
     }
 
     public FileDownloader.asynchronous(string uri, string destination,
                                        Cancellable? cancellable = null,
                                        owned FileProgressCallback? callback = null) throws Error {
-        this(uri, destination, cancellable, callback);
+        this(uri, destination, cancellable, (owned) callback);
         synchronously = false;
     }
 

--- a/src/Common/LinuxKernel.vala
+++ b/src/Common/LinuxKernel.vala
@@ -196,7 +196,7 @@ public class LinuxKernel : GLib.Object, Gee.Comparable<LinuxKernel> {
 			cancelled = false;
 			var worker = new Thread<void>.try(null, () => {
 				try {
-					query_thread(notifier);
+					query_thread((owned) notifier);
 				} catch (Error e) {
 					log_error (e.message);
 				}

--- a/src/Gtk/MainWindow.vala
+++ b/src/Gtk/MainWindow.vala
@@ -439,7 +439,7 @@ public class MainWindow : Gtk.Window{
 
 				try {
 					var changelog = new FileDownloader.asynchronous(selected_kernels[0].changes_file_uri, selected_kernels[0].changes_file, cancellable);
-					changelog.on_failure = handle_failure;
+					changelog.on_failure = (error) => handle_failure(error);
 					changelog.on_finished = () => progress_window.destroy();
 					changelog.start();
 


### PR DESCRIPTION
Delegates shouldn't be copied as it can lead to use-after-free or double-free.

Warnings on this issue are exposed when disabling --enable-deprecated.

Fore more details see: https://stackoverflow.com/questions/16693847/how-to-get-rid-of-the-vala-compilation-warning-copying-delegates-is-discouraged/16697408#16697408