### PR TITLE
Don't rely on shenanigans to decide to update the main index

### DIFF
--- a/src/Common/LinuxKernel.vala
+++ b/src/Common/LinuxKernel.vala
@@ -219,16 +219,9 @@ public class LinuxKernel : GLib.Object, Gee.Comparable<LinuxKernel> {
 		log_debug("query_thread() App.show_prev_majors: %d".printf(App.show_prev_majors));
 		log_debug("query_thread() App.hide_unstable: "+App.hide_unstable.to_string());
 
-		//DownloadManager.reset_counter();
-
-		// download main index.html if stale
-		bool refresh = false;
-		var one_hour_before = (new DateTime.now_local()).add_hours(-1);
-		if (last_refreshed_date.compare(one_hour_before) < 0) refresh = true;
 		bool is_connected = Main.can_reach_mainline_ppa();
-		if (refresh) download_index();
 
-		// read main index.html
+		download_index();
 		load_index();
 
 		// TODO: Implement locking for multiple download threads
@@ -855,17 +848,6 @@ public class LinuxKernel : GLib.Object, Gee.Comparable<LinuxKernel> {
 	public static string index_page{
 		owned get {
 			return "%s/index.html".printf(CACHE_DIR);
-		}
-	}
-
-	public static DateTime last_refreshed_date{
-		owned get{
-			if (file_get_size(index_page) < 300000){
-				return (new DateTime.now_local()).add_years(-1);
-			}
-			else{
-				return file_get_modified_date(index_page);
-			}
 		}
 	}
 

--- a/src/Utility/TeeJee.FileSystem.vala
+++ b/src/Utility/TeeJee.FileSystem.vala
@@ -196,22 +196,6 @@ namespace TeeJee.FileSystem{
 		return -1;
 	}
 
-	public DateTime file_get_modified_date(string file_path){
-		try{
-			FileInfo info;
-			File file = File.parse_name (file_path);
-			if (file.query_exists()) {
-				info = file.query_info("%s".printf(FileAttribute.TIME_MODIFIED), 0);
-				return (new DateTime.from_timeval_utc(info.get_modification_time())).to_local();
-			}
-		}
-		catch (Error e) {
-			log_error (e.message);
-		}
-		
-		return (new DateTime.from_unix_utc(0)); //1970
-	}
-
 	// directory helpers ----------------------
 	
 	public bool dir_exists (string dir_path){


### PR DESCRIPTION
We should not try to update the main index based on the age of our cached file. Moreover, it was never the case as it was implicitly disabled for "small" (<300Kb) files and the index.html file is around 280Kib.

That's also two fewer usages of deprecated functions!