### PR TITLE
Don't add a useless space to button's label

### DIFF
--- a/src/Utility/Gtk/AboutWindow.vala
+++ b/src/Utility/Gtk/AboutWindow.vala
@@ -268,7 +268,7 @@ public class AboutWindow : Dialog {
 		hbox_action = (Box) get_action_area();
 
 		//btn_credits
-		btn_credits = new Button.with_label("  " + _("Credits"));
+		btn_credits = new Button.with_label(_("Credits"));
 		btn_credits.set_image (new Image.from_icon_name ("gtk-about", IconSize.MENU));
 		hbox_action.add(btn_credits);
 
@@ -281,17 +281,17 @@ public class AboutWindow : Dialog {
 			}
 
 			if (vbox_credits.visible){
-				btn_credits.label = "  " + _("Back");
+				btn_credits.label = _("Back");
 				btn_credits.set_image (new Image.from_icon_name ("gtk-go-back", IconSize.MENU));
 			}
 			else{
-				btn_credits.label = "  " + _("Credits");
+				btn_credits.label = _("Credits");
 				btn_credits.set_image (new Image.from_icon_name ("gtk-about", IconSize.MENU));
 			}
 		});
 
 		//btn_close
-		btn_close = new Button.with_label("  " + _("Close"));
+		btn_close = new Button.with_label(_("Close"));
 		btn_close.set_image (new Image.from_icon_name ("gtk-close", IconSize.MENU));
 		hbox_action.add(btn_close);
 


### PR DESCRIPTION
Before:
![one](https://user-images.githubusercontent.com/26030965/220485579-2b2ec699-265e-4dc0-87b3-562164bdd4f2.png)

After:
![two](https://user-images.githubusercontent.com/26030965/220485584-26a0590e-e938-4721-a855-5c5f42f2a0f4.png)
