### PR TITLE
Don't set `rewrap_on_resize` in TerminalWindow

### DIFF
--- a/src/Gtk/TerminalWindow.vala
+++ b/src/Gtk/TerminalWindow.vala
@@ -114,7 +114,6 @@ public class TerminalWindow : Gtk.Window {
 		term.backspace_binding = Vte.EraseBinding.AUTO;
 		term.cursor_blink_mode = Vte.CursorBlinkMode.SYSTEM;
 		term.cursor_shape = Vte.CursorShape.UNDERLINE;
-		term.rewrap_on_resize = true;
 		
 		term.scroll_on_keystroke = true;
 		term.scroll_on_output = true;


### PR DESCRIPTION
This setting is deprecated and rewrapping is now the default and invariable behavior of Vte.Terminal().
See: https://gitlab.gnome.org/GNOME/vte/-/issues/135