### PR TITLE
Cast `TreeView` to a `Scrollable` before calling `get_[h,v]adjustment()`

### DIFF
--- a/src/Gtk/MainWindow.vala
+++ b/src/Gtk/MainWindow.vala
@@ -136,7 +136,7 @@ public class MainWindow : Gtk.Window{
 
 		tv.get_selection().changed.connect(tv_selection_changed);
 
-		var scrollwin = new ScrolledWindow(tv.get_hadjustment(), tv.get_vadjustment());
+		var scrollwin = new ScrolledWindow(((Gtk.Scrollable) tv).get_hadjustment(), ((Gtk.Scrollable) tv).get_vadjustment());
 		scrollwin.set_shadow_type (ShadowType.ETCHED_IN);
 		scrollwin.add (tv);
 		hbox_list.add(scrollwin);


### PR DESCRIPTION
Even if this is a workaround for a what is a vapigen quirk, it removes two deprecation warnings.
It doesn't cost much, and anyway it should go when we port this to GTK4.