### PR TITLE
make --install-point offer latest point releases only again

### DIFF
--- a/src/Console/AppConsole.vala
+++ b/src/Console/AppConsole.vala
@@ -193,9 +193,13 @@ public class AppConsole : GLib.Object {
 			break;
 
 		case "--install-latest":
-		case "--install-point":
 
 			LinuxKernel.kinst_latest(false, App.confirm);
+			break;
+
+		case "--install-point":
+
+			LinuxKernel.kinst_latest(true, App.confirm);
 			break;
 
 		case "--purge-old-kernels":	// back compat


### PR DESCRIPTION
Commit d7943e56e7b73a2d96b862195f514e9c0dca0c5c ("readme wips") accidentally merged the cases for "--install-latest" and "--install-point", missing that "--install-point" uses different parameters for LinuxKernel::kinst_latest().

Fix this by restoring the separate case for "--install-point" and let it pass true again to LinuxKernel::kinst_latest() for point_update.

Before:

    $ mainline --install 6.1.15
    ...
    $ mainline --install-point
    mainline 1.1.4
    Distribution: Ubuntu 22.04.2 LTS
    Architecture: amd64
    Running kernel: 5.19.0-35-generic
    Updating from:
    https://kernel.ubuntu.com/~kernel-ppa/mainline/
    OK
    Found installed : 5.15.0-67.74
    Found installed : 5.19.0-35.36~22.04.1
    Found installed : 5.15.0.67.65
    Found installed : 5.19.0.35.36~22.04.10
    Found installed : 6.1.15-060115.202303030632
    Latest update: 6.2.3

    Install Kernel Version 6.2.3 ? (y/n):

After:

    $ mainline --install-point
    mainline 1.1.4
    Distribution: Ubuntu 22.04.2 LTS
    Architecture: amd64
    Running kernel: 5.19.0-35-generic
    Updating from:
    https://kernel.ubuntu.com/~kernel-ppa/mainline/
    OK
    Found installed : 5.15.0-67.74
    Found installed : 5.19.0-35.36~22.04.1
    Found installed : 5.15.0.67.65
    Found installed : 5.19.0.35.36~22.04.10
    Found installed : 6.1.15-060115.202303030632
    Latest point update: 6.1.16

    Install Kernel Version 6.1.16 ? (y/n):

Fixes #167