### PR TITLE
Add override dh_builddeb to use xz compression on issue #121

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -18,3 +18,6 @@
 
 %:
 	dh $@ --no-parallel
+
+override_dh_builddeb:
+	dh_builddeb -- -Zxz


### PR DESCRIPTION
The -Zxz option is passed to dpkg-deb through dh_builddeb with "--".

It instructs dpkg-deb to use the 'xz' compression format for the resulting .deb package. 'xz' is a widely used compression algorithm in Debian packages, known for its high compression ratio. 

So, it won't cause problem like "dpkg-deb: error: archive uses unknown compression for member 'control.tar.zst' "

https://github.com/bkw777/mainline/issues/121