### PR TITLE
Fix aria2c argv quoting in spawn path (--all-proxy / --user-agent)

### DIFF
--- a/src/Common/DownloadManager.vala
+++ b/src/Common/DownloadManager.vala
@@ -70,9 +70,9 @@ public class DownloadTask : AsyncTask {
 			cmd += "--max-connection-per-server="+App.concurrent_downloads.to_string();
 		}
 
-		if (App.all_proxy.length>0) cmd += "--all-proxy='"+App.all_proxy+"'";
+		if (App.all_proxy.length>0) cmd += "--all-proxy="+App.all_proxy;
 
-		if (App.user_agent.length>0) cmd += "--user-agent='"+App.user_agent+"'";
+		if (App.user_agent.length>0) cmd += "--user-agent="+App.user_agent;
 
 		spawn_args = cmd;
 	}


### PR DESCRIPTION
## Summary

`DownloadManager.vala` builds aria2c's argv as a string array passed
directly to GLib's `Process.spawn_async` (no shell), but the
`--all-proxy=` and `--user-agent=` values were wrapped in literal
single quotes. The quote characters became part of the argv elements
themselves, so aria2c rejected the proxy with `unrecognized proxy
format` and the User-Agent header was sent with literal `'` embedded.

## Reproduction (before this fix)

1. Set Settings → Proxy URL to `http://127.0.0.1:8118` (any HTTP proxy)
2. Run `mainline list`
3. The list comes back empty with:
   ```
   Exception: errorCode=28 We encountered a problem while processing the option '--all-proxy'.
     -> errorCode=1 unrecognized proxy format
   FAILED
   !!! kernel_list empty!
   ```

`strace -f -e trace=execve` shows the spawn-path argv literally
contains the quote characters:

```
"--all-proxy='http://127.0.0.1:8118'"
"--user-agent='Mozilla/5.0 ...'"
```

## Fix

Drop the literal single quotes in `src/Common/DownloadManager.vala`:

```diff
-if (App.all_proxy.length>0) cmd += "--all-proxy='"+App.all_proxy+"'";
-if (App.user_agent.length>0) cmd += "--user-agent='"+App.user_agent+"'";
+if (App.all_proxy.length>0) cmd += "--all-proxy="+App.all_proxy;
+if (App.user_agent.length>0) cmd += "--user-agent="+App.user_agent;
```

The corresponding lines in `src/Common/Main.vala` (`try_ppa()`) are
intentionally left as-is — that path uses `exec_sync` →
`Process.spawn_command_line_sync`, which performs shell-style
argument parsing and strips the quotes correctly.

## Test plan

- [x] Build with `make`
- [x] `strace -f -e trace=execve mainline list` shows clean argv
      (`--all-proxy=http://127.0.0.1:8118`, `--user-agent=Mozilla/5.0 …`,
      no embedded quotes)
- [x] `mainline list` returns the kernel list when a proxy is set
- [x] No regression with empty proxy / empty user-agent (verified via
      strace: neither flag appears in argv when config values are empty)